### PR TITLE
Update compatibility to v9

### DIFF
--- a/module.json
+++ b/module.json
@@ -11,7 +11,7 @@
         "./scripts/dnd5e-character-monitor.js"
     ],
     "minimumCoreVersion": "0.8.1",
-    "compatibleCoreVersion": "0.8.9",
+    "compatibleCoreVersion": "9",
     "languages": [
         {
             "lang": "en",


### PR DESCRIPTION
This mod seems to be working fine in Foundry V9, there are also no tickets currently pending on it. I suggest updating the compatibleCoreVersion to get rid of the Compatibility Risk warning