### PR TITLE
Use CSS for styling, plus other fixes/improvements

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -33,6 +33,10 @@
                 "name": "Display Character Monitor to GM Users only",
                 "hint": "Chat messages can be revealed to players using context menu."
             },
+            "allowPlayerView": {
+                "name": "Allow players to see their own messages",
+                "hint": "If GM-only mode is enabled, this setting allows players to still see their own monitor messages."
+            },
             "showToggle": {
                 "name": "Show Character Monitor Toggle",
                 "hint": "Temporarily disable Character Monitor by toggling off the control button on the token toolbar. The control button is only visible to GM users."

--- a/module.json
+++ b/module.json
@@ -10,6 +10,9 @@
     "esmodules": [
         "./scripts/dnd5e-character-monitor.js"
     ],
+    "styles": [
+        "./styles/dnd5e-character-monitor.css"
+    ],
     "minimumCoreVersion": "0.8.1",
     "compatibleCoreVersion": "9",
     "languages": [

--- a/scripts/dnd5e-character-monitor.js
+++ b/scripts/dnd5e-character-monitor.js
@@ -211,7 +211,10 @@ class CharacterMonitor {
 
     static registerReadyHooks() {
         // Equipment, Spell Preparation, and Feature changes
-        Hooks.on("preUpdateItem", async (item, data, options, userID) => {
+        Hooks.on("updateItem", async (item, data, options, userID) => {
+            const GMconnected = getGM();
+            if (GMconnected) return;
+            
             // If owning character sheet is not open, then change was not made via character sheet, return
             //if (Object.keys(item.parent?.apps || {}).length === 0) return;
 
@@ -309,7 +312,10 @@ class CharacterMonitor {
             }
         });
 
-        Hooks.on("preUpdateActor", async (actor, data, options, userID) => {
+        Hooks.on("updateActor", async (actor, data, options, userID) => {
+            const GMconnected = getGM();
+            if (GMconnected) return;
+
             const whisper = game.settings.get(moduleName, "showGMonly") ?
                 game.users.filter(u => u.isGM).map(u => u.id) : [];
 
@@ -494,4 +500,10 @@ async function checkSecondHooks(params = {}) {
 
     const res = await Promise.all(promises);
     return res.includes(true);
+}
+
+function getGM() {
+    const activeGMs = game.users.filter(u => u.isGM && u.active);
+    if (!activeGMs.length) return false;
+    return activeGMs[0].id && activeGMs[0].id !== game.user.id;
 }

--- a/scripts/dnd5e-character-monitor.js
+++ b/scripts/dnd5e-character-monitor.js
@@ -1,16 +1,18 @@
 const moduleName = "dnd5e-character-monitor";
 // Setting CONSTS
 let trashIconSetting;
-const classToColorSettingDict = {
-    "cm-on": "on",
-    "cm-off": "off",
-    "cm-slots": "slots",
-    "cm-feats": "feats"
-};
+const TEMPLATE_DIR = `modules/${moduleName}/templates`
+const ITEM_EQUIP_TEMPLATE = `${TEMPLATE_DIR}/itemEquip.hbs`;
+const ITEM_ATTUNE_TEMPLATE = `${TEMPLATE_DIR}/itemAttune.hbs`;
+const SPELL_PREPARE_TEMPLATE = `${TEMPLATE_DIR}/spellPrepare.hbs`;
+const FEAT_USES_TEMPLATE = `${TEMPLATE_DIR}/featUses.hbs`;
+const SPELL_SLOTS_TEMPLATE = `${TEMPLATE_DIR}/spellSlots.hbs`;
+const RESOURCE_USES_TEMPLATE = `${TEMPLATE_DIR}/resourceUses.hbs`;
 
-
-Hooks.once("init", () => {
+Hooks.once("init", async () => {
     console.log(`${moduleName} | Initializing`);
+
+    await loadTemplates([ITEM_EQUIP_TEMPLATE, ITEM_ATTUNE_TEMPLATE, SPELL_PREPARE_TEMPLATE, FEAT_USES_TEMPLATE, SPELL_SLOTS_TEMPLATE, RESOURCE_USES_TEMPLATE]);
 
     // Open module API
     window.CharacterMonitor = CharacterMonitor;
@@ -53,7 +55,7 @@ class CharacterMonitor {
                 feats: "#425af5"
             },
             config: false,
-            onChange: () => window.location.reload()
+            onChange: () => CharacterMonitor.setColors()
         });
 
 
@@ -154,6 +156,17 @@ class CharacterMonitor {
             default: true,
             config: false
         });
+
+        CharacterMonitor.setColors();
+    }
+
+    static setColors() {
+        const root = document.querySelector(':root');
+        const colors = game.settings.get(moduleName, "cmColors");
+        root.style.setProperty('--dnd5e-cm-on', colors.on);
+        root.style.setProperty('--dnd5e-cm-off', colors.off);
+        root.style.setProperty('--dnd5e-cm-feats', colors.feats);
+        root.style.setProperty('--dnd5e-cm-slots', colors.slots);
     }
 
     // Hooks --------
@@ -178,40 +191,27 @@ class CharacterMonitor {
 
         // Apply custom CSS to Character Monitor chat messages
         Hooks.on("renderChatMessage", (app, html, data) => {
-            const cmMessage = html.find(`.cm-message`);
-            if (!cmMessage.length) return;
+            const flags = data?.message?.flags[moduleName];
+            if (!flags) return;
 
-            const cmClass = cmMessage[0].classList[1];
-            const settingKey = classToColorSettingDict[cmClass]
-            const backgroundColor = game.settings.get(moduleName, "cmColors")[settingKey];
-            html.css("background", backgroundColor); // TODO: figure out coloring mechanism
-            html.css("text-shadow", "-1px -1px 0 #000 , 1px -1px 0 #000 , -1px 1px 0 #000 , 1px 1px 0 #000");
-            html.css("color", "white");
-            html.css("text-align", "center");
-            html.css("font-size", "12px");
-            html.css("margin", "2px");
-            html.css("padding", "2px");
-            html.css("border", "2px solid #191813d6");
-            html.find(".message-sender").text("");
-            html.find(".message-metadata")[0].style.display = "none";
+            if ("equip" in flags) {
+                html.addClass(`dnd5e-cm-message dnd5e-cm-${flags.equip ? "on" : "off"}`);
+            } else if ("feat" in flags) {
+                html.addClass("dnd5e-cm-message dnd5e-cm-feats");
+            } else if ("slot" in flags) {
+                html.addClass("dnd5e-cm-message dnd5e-cm-slots");
+            }
 
             // Optionally add trash icon
             if (trashIconSetting && game.user.isGM) {
-                const cmMessageDiv = html.find(`div.cm-message`);
-                cmMessageDiv.css("position", "relative");
-                $(cmMessageDiv).find(`span`).after(`<span><a class="button message-delete"><i class="fas fa-trash"></i></a></span>`);
-
-                html.find(`a.message-delete`).closest(`span`).css("position", "absolute");
-                html.find(`a.message-delete`).closest(`span`).css("left", "95%");
+                html.find('div.dnd5e-cm-content').append('<span class="dnd5e-cm-trash"><a class="button message-delete"><i class="fas fa-trash"></i></a></span>');
             }
         });
     }
 
     static registerReadyHooks() {
         // Equipment, Spell Preparation, and Feature changes
-        Hooks.on("updateItem", async (item, data, options, userID) => {
-            if (!game.user.isGM) return;
-
+        Hooks.on("preUpdateItem", async (item, data, options, userID) => {
             // If owning character sheet is not open, then change was not made via character sheet, return
             //if (Object.keys(item.parent?.apps || {}).length === 0) return;
 
@@ -239,128 +239,152 @@ class CharacterMonitor {
             const whisper = game.settings.get(moduleName, "showGMonly") ?
                 game.users.filter(u => u.isGM).map(u => u.id) : [];
 
-            // Prepare common chat message content
-            const characterName = item.parent.name;
-            const itemName = item.name;
+            // Prepare common content for handlebars templates
+            const hbsData = {
+                characterName: item.parent.name,
+                itemName: item.name
+            };
 
             if (isEquip) {
-                const content = `
-                    <div class="cm-message cm-${data.data.equipped ? "on" : "off"}">
-                    <span style="padding-right: 5%">
-                            ${characterName} ${data.data.equipped ? game.i18n.localize("characterMonitor.chatMessage.equipped") : game.i18n.localize("characterMonitor.chatMessage.unequipped")}: ${itemName}
-                        </span>
-                    </div>
-                `;
-
-                await ChatMessage.create({
-                    content,
-                    whisper
+                hbsData.equipped = data.data.equipped;
+                renderTemplate(ITEM_EQUIP_TEMPLATE, hbsData).then(async (content) => {
+                    await ChatMessage.create({
+                        content,
+                        whisper,
+                        flags: { [moduleName]: { equip: data.data.equipped } }
+                    });
                 });
             }
 
             if (isSpellPrep) {
-                const content = `
-                    <div class="cm-message cm-${data.data.preparation.prepared ? "on" : "off"}">
-                        <span>
-                            ${characterName} ${data.data.preparation.prepared ? game.i18n.localize("characterMonitor.chatMessage.prepared") : game.i18n.localize("characterMonitor.chatMessage.unprepared")} ${game.i18n.localize("characterMonitor.chatMessage.aSpell")}: ${itemName}
-                        </span>
-                    </div>
-                `;
-
-                await ChatMessage.create({
-                    content,
-                    whisper
+                hbsData.prepared = data.data.preparation.prepared;
+                renderTemplate(SPELL_PREPARE_TEMPLATE, hbsData).then(async (content) => {
+                    await ChatMessage.create({
+                        content,
+                        whisper,
+                        flags: { [moduleName]: { equip: data.data.preparation.prepared } }
+                    });
                 });
             }
 
             if (isFeat) {
-                const content = `
-                    <div class="cm-message cm-feats">
-                        <span style="padding-right: 5%">
-                            ${characterName} | ${itemName}: ${item.data.data.uses.value}/${item.data.data.uses.max} ${game.i18n.localize("characterMonitor.chatMessage.uses")}
-                        </span>
-                    </div>
-                `;
+                const newUses = data.data.uses;
+                const oldUses = item.data.data.uses;
+                const hasValue = ("value" in newUses);
+                const hasMax = ("max" in newUses);
+                if (!hasValue && !hasMax) return;
 
-                // Determine if update was initiated by item being rolled
-                const itemRolled = await checkSecondHook("createChatMessage");
-                if (!itemRolled) {
+                // Ignore any updates that attempt to change values between zero <--> null.
+                const isValueUnchanged = (!hasValue || (!newUses.value && !oldUses.value));
+                const isMaxUnchanged = (!hasMax || (!newUses.max && !oldUses.max));
+                if (isValueUnchanged && isMaxUnchanged) return;
+
+                // Determine if update was initiated by item being rolled, or a rest
+                checkSecondHooks({ itemId: item.id }).then(async (didFire) => {
+                    if (didFire) return;
+
+                    hbsData.uses = {
+                        value: (hasValue ? newUses.value : oldUses.value) || 0,
+                        max: (hasMax ? newUses.max : oldUses.max) || 0
+                    };
+                    const content = await renderTemplate(FEAT_USES_TEMPLATE, hbsData);
+
                     await ChatMessage.create({
                         content,
-                        whisper
+                        whisper,
+                        flags: { [moduleName]: { feat: true } }
                     });
-                }
+                });
             }
 
-            if (isAttune && (data.data.attunement === 1 || data.data.attunement === 2)) {
-                const attuneStatus = data.data.attunement === 2 ? game.i18n.localize("characterMonitor.chatMessage.attunesTo") : game.i18n.localize("characterMonitor.chatMessage.breaksAttune");
-                const content = `
-                    <div class="cm-message cm-${data.data.attunement === 2 ? "on" : "off"}">
-                        <span style="padding-right: 5%">
-                            ${characterName} ${attuneStatus}: ${itemName}
-                        </span>
-                    </div>
-                `;
-
-                await ChatMessage.create({
-                    content,
-                    whisper
+            if (isAttune && (CONFIG.DND5E.attunementTypes.NONE !== data.data.attunement)) {
+                hbsData.attuned = (CONFIG.DND5E.attunementTypes.ATTUNED === data.data.attunement);
+                renderTemplate(ITEM_ATTUNE_TEMPLATE, hbsData).then(async (content) => {
+                    await ChatMessage.create({
+                        content,
+                        whisper,
+                        flags: { [moduleName]: { equip: hbsData.attuned } }
+                    });
                 });
             }
         });
 
-        Hooks.on("updateActor", async (actor, data, options, userID) => {
-            if (!game.user.isGM) return;
-
+        Hooks.on("preUpdateActor", async (actor, data, options, userID) => {
             const whisper = game.settings.get(moduleName, "showGMonly") ?
                 game.users.filter(u => u.isGM).map(u => u.id) : [];
-            const characterName = actor.name;
+
+            const hbsData = {
+                characterName: actor.name
+            }
 
             // Spell Slot changes
             if (game.settings.get(moduleName, "monitorSpellSlots") && ("spells" in (data.data || {}))) {
-                // Determine if update was initiated by item being rolled
-                const itemRolled = await checkSecondHook("createChatMessage");
-                if (itemRolled) return;
+                for (const [spellLevel, newSpellData] of Object.entries(data.data.spells)) {
+                    const oldSpellData = actor.data.data.spells[spellLevel];
+                    const hasValue = ("value" in newSpellData);
+                    const hasMax = ("override" in newSpellData) || ("max" in newSpellData);
+                    if (!hasValue && !hasMax) return;
 
-                for (const spellLevel of Object.keys(data.data.spells)) {
+                    const newMax = newSpellData.override ?? newSpellData.max;
+
+                    // Ignore any updates that attempt to change values between zero <--> null.
+                    const isValueUnchanged = (!hasValue || (!newSpellData.value && !oldSpellData.value));
+                    const isMaxUnchanged = (!hasMax || (!newMax && !oldSpellData.max));
+                    if (isValueUnchanged && isMaxUnchanged) return;
+
                     const levelNum = parseInt(spellLevel.slice(-1));
-                    const levelLabel = CONFIG.DND5E.spellLevels[levelNum];
-                    const content = `
-                        <div class="cm-message cm-slots">
-                            <span style="padding-right: 5%">
-                                ${characterName} | ${levelLabel} ${game.i18n.localize("characterMonitor.chatMessage.SpellSlots")}: ${actor.data.data.spells[spellLevel].value}/${actor.data.data.spells[spellLevel].max}
-                            </span>
-                        </div>
-                    `;
 
-                    await ChatMessage.create({
-                        content,
-                        whisper
+                    // Determine if update was initiated by item being rolled, or a rest.
+                    checkSecondHooks({ spellLevel: levelNum }).then(async (didFire) => {
+                        if (didFire) return;
+
+                        hbsData.spellSlot = {
+                            label: CONFIG.DND5E.spellLevels[levelNum],
+                            value: (hasValue ? newSpellData.value : oldSpellData.value) || 0,
+                            max: (newMax ?? oldSpellData.max) || 0
+                        }
+
+                        const content = await renderTemplate(SPELL_SLOTS_TEMPLATE, hbsData);
+
+                        await ChatMessage.create({
+                            content,
+                            whisper,
+                            flags: { [moduleName]: { slot: levelNum } }
+                        });
                     });
                 }
             }
 
             // Resource Changes
             if (game.settings.get(moduleName, "monitorResources") && ("resources" in (data.data || {}))) {
-                const isRest = checkSecondHook("restCompleted");
-                const itemRolled = checkSecondHook("createChatMessage");
-                const res = await Promise.all([isRest, itemRolled]);
-                if (res.includes(true)) return;
+                for (const [resource, newResourceData] of Object.entries(data.data.resources)) {
+                    const hasValue = ("value" in newResourceData);
+                    const hasMax = ("max" in newResourceData);
+                    if (!hasValue && !hasMax) continue;
 
-                for (const resource of Object.keys(data.data.resources)) {
-                    if (!(("value" in data.data.resources[resource]) || ("max" in data.data.resources[resource]))) continue;
+                    const oldResourceData = actor.data.data.resources[resource];
 
-                    const content = `
-                        <div class="cm-message cm-feats">
-                            <span style="padding-right: 5%">
-                                ${characterName} | ${actor.data.data.resources[resource].label || resource}: ${actor.data.data.resources[resource].value} / ${actor.data.data.resources[resource].max || "0"}
-                            </span>
-                        </div>
-                    `;
+                    // Ignore any updates that attempt to change values between zero <--> null.
+                    const isValueUnchanged = (!hasValue || (!newResourceData.value && !oldResourceData.value));
+                    const isMaxUnchanged = (!hasMax || (!newResourceData.max && !oldResourceData.max));
+                    if (isValueUnchanged && isMaxUnchanged) continue;
 
-                    await ChatMessage.create({
-                        content,
-                        whisper
+                    // Determine if update was initiated by item being rolled, or a rest.
+                    checkSecondHooks({ resourceName: resource }).then(async (didFire) => {
+                        if (didFire) return;
+
+                        hbsData.resource = {
+                            label: oldResourceData.label || resource,
+                            value: (hasValue ? newResourceData.value : oldResourceData.value) || 0,
+                            max: (hasMax ? newResourceData.max : oldResourceData.max) || 0
+                        };
+                        const content = await renderTemplate(RESOURCE_USES_TEMPLATE, hbsData);
+
+                        await ChatMessage.create({
+                            content,
+                            whisper,
+                            flags: { [moduleName]: { feat: true } }
+                        });
                     });
                 }
             }
@@ -423,18 +447,51 @@ class CharacterMonitorColorMenu extends FormApplication {
     }
 }
 
-
-async function checkSecondHook(secondHookName, delay = 500) {
+async function checkSecondHook(secondHookName, { itemId, spellLevel, resourceName, delay = 500 } = {}) {
     let secondHookCalled = false;
-    const hookID = Hooks.once(secondHookName, () => {
-        secondHookCalled = true;
+
+    const hookID = Hooks.on(secondHookName, (...args) => {
+        if (secondHookName === "preCreateChatMessage") {
+            const html = $($.parseHTML(args[1].content));
+
+            if (itemId) {
+                secondHookCalled ||= html.is(`[data-item-id="${itemId}"]`);
+
+            } else if (spellLevel) {
+                secondHookCalled ||= html.is(`[data-spell-level="${spellLevel}"]`);
+
+            } else if (resourceName) {
+                const actor = game.actors.get(args[1].speaker.actor);
+                if (!actor) return;
+
+                const item = actor.items.get(html.attr("data-item-id"));
+                if (!item) return;
+
+                secondHookCalled ||= (item.data.data.consume.target === `resources.${resourceName}.value`);
+
+            } else {
+                secondHookCalled = true;
+            }
+        } else {
+            secondHookCalled = true;
+        }
     });
 
     await new Promise(resolve => {
         setTimeout(resolve, delay);
     });
 
-    if (!secondHookCalled) Hooks.off(secondHookName, hookID);
+    Hooks.off(secondHookName, hookID);
 
     return secondHookCalled;
+}
+
+async function checkSecondHooks(params = {}) {
+    const promises = [
+        checkSecondHook("preCreateChatMessage", params),
+        checkSecondHook("restCompleted", params)
+    ];
+
+    const res = await Promise.all(promises);
+    return res.includes(true);
 }

--- a/scripts/dnd5e-character-monitor.js
+++ b/scripts/dnd5e-character-monitor.js
@@ -211,10 +211,7 @@ class CharacterMonitor {
 
     static registerReadyHooks() {
         // Equipment, Spell Preparation, and Feature changes
-        Hooks.on("updateItem", async (item, data, options, userID) => {
-            const GMconnected = getGM();
-            if (GMconnected) return;
-            
+        Hooks.on("preUpdateItem", async (item, data, options, userID) => {
             // If owning character sheet is not open, then change was not made via character sheet, return
             //if (Object.keys(item.parent?.apps || {}).length === 0) return;
 
@@ -312,10 +309,7 @@ class CharacterMonitor {
             }
         });
 
-        Hooks.on("updateActor", async (actor, data, options, userID) => {
-            const GMconnected = getGM();
-            if (GMconnected) return;
-
+        Hooks.on("preUpdateActor", async (actor, data, options, userID) => {
             const whisper = game.settings.get(moduleName, "showGMonly") ?
                 game.users.filter(u => u.isGM).map(u => u.id) : [];
 
@@ -500,10 +494,4 @@ async function checkSecondHooks(params = {}) {
 
     const res = await Promise.all(promises);
     return res.includes(true);
-}
-
-function getGM() {
-    const activeGMs = game.users.filter(u => u.isGM && u.active);
-    if (!activeGMs.length) return false;
-    return activeGMs[0].id && activeGMs[0].id !== game.user.id;
 }

--- a/styles/dnd5e-character-monitor.css
+++ b/styles/dnd5e-character-monitor.css
@@ -3,9 +3,11 @@
     --dnd5e-cm-off: #c50d19;
     --dnd5e-cm-feats: #425af5;
     --dnd5e-cm-slots: #b042f5;
+    --dnd5e-cm-display: 'flex';
 }
 
 .message.dnd5e-cm-message {
+    display: var(--dnd5e-cm-display);
     text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
     color: white;
     text-align: center;

--- a/styles/dnd5e-character-monitor.css
+++ b/styles/dnd5e-character-monitor.css
@@ -1,0 +1,49 @@
+:root {
+    --dnd5e-cm-on: #06a406;
+    --dnd5e-cm-off: #c50d19;
+    --dnd5e-cm-feats: #425af5;
+    --dnd5e-cm-slots: #b042f5;
+}
+
+.message.dnd5e-cm-message {
+    text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
+    color: white;
+    text-align: center;
+    font-size: 12px;
+    margin: 2px;
+    padding: 2px;
+    border: 2px solid #191813d6;
+}
+
+.message.dnd5e-cm-message.dnd5e-cm-on {
+	background: var(--dnd5e-cm-on);
+}
+
+.message.dnd5e-cm-message.dnd5e-cm-off {
+	background: var(--dnd5e-cm-off);
+}
+
+.message.dnd5e-cm-message.dnd5e-cm-feats {
+	background: var(--dnd5e-cm-feats);
+}
+
+.message.dnd5e-cm-message.dnd5e-cm-slots {
+	background: var(--dnd5e-cm-slots);
+}
+
+.message.dnd5e-cm-message header.message-header {
+    display: none !important;
+}
+
+.message.dnd5e-cm-message div.dnd5e-cm-content {
+    position: relative;
+}
+
+.message.dnd5e-cm-message span.dnd5e-cm-text {
+    padding-right: 5%;
+}
+
+.message.dnd5e-cm-message span.dnd5e-cm-trash {
+    position: absolute;
+    left: 95%;
+}

--- a/templates/featUses.hbs
+++ b/templates/featUses.hbs
@@ -1,0 +1,5 @@
+<div class="dnd5e-cm-content">
+    <span class="dnd5e-cm-text">
+        {{characterName}} | {{itemName}}: {{uses.value}}/{{uses.max}} {{localize "characterMonitor.chatMessage.uses"}}
+    </span>
+</div>

--- a/templates/itemAttune.hbs
+++ b/templates/itemAttune.hbs
@@ -1,0 +1,5 @@
+<div class="dnd5e-cm-content">
+    <span class="dnd5e-cm-text">
+        {{characterName}} {{#if attuned}}{{localize "characterMonitor.chatMessage.attunesTo"}}{{else}}{{localize "characterMonitor.chatMessage.breaksAttune"}}{{/if}}: {{itemName}}
+    </span>
+</div>

--- a/templates/itemEquip.hbs
+++ b/templates/itemEquip.hbs
@@ -1,0 +1,5 @@
+<div class="dnd5e-cm-content">
+    <span class="dnd5e-cm-text">
+        {{characterName}} {{#if equipped}}{{localize "characterMonitor.chatMessage.equipped"}}{{else}}{{localize "characterMonitor.chatMessage.unequipped"}}{{/if}} {{itemName}}
+    </span>
+</div>

--- a/templates/resourceUses.hbs
+++ b/templates/resourceUses.hbs
@@ -1,0 +1,5 @@
+<div class="dnd5e-cm-content">
+    <span class="dnd5e-cm-text">
+        {{characterName}} | {{resource.label}}: {{resource.value}}/{{resource.max}}
+    </span>
+</div>

--- a/templates/spellPrepare.hbs
+++ b/templates/spellPrepare.hbs
@@ -1,0 +1,5 @@
+<div class="dnd5e-cm-content">
+    <span class="dnd5e-cm-text">
+        {{characterName}} {{#if prepared}}{{localize "characterMonitor.chatMessage.prepared"}}{{else}}{{localize "characterMonitor.chatMessage.unprepared"}}{{/if}} {{localize "characterMonitor.chatMessage.aSpell"}}: {{itemName}}
+    </span>
+</div>

--- a/templates/spellSlots.hbs
+++ b/templates/spellSlots.hbs
@@ -1,0 +1,5 @@
+<div class="dnd5e-cm-content">
+    <span class="dnd5e-cm-text">
+        {{characterName}} | {{spellSlot.label}} {{localize "characterMonitor.chatMessage.SpellSlots"}}: {{spellSlot.value}}/{{spellSlot.max}}
+    </span>
+</div>


### PR DESCRIPTION
- Use handlebars templates to create the messages
- Use `preUpdate...` hooks, so that only the player that made the change triggers the message creation.
  - Previously, the GM would create the message, but if the GM is not currently connected, then no message would be created.
  - Also, if multiple GMs were connected, you would get the message multiple times.
  - This also now means that the user can see their own monitor messages when GM-only is enabled.
- Don't display an update when values change between 0/null/undefined
- Don't `await` in hooks, so that all monitors can be tested before any secondary messages are created.
  - Previously, if multiple updates happened at once, and the second one required waiting for a secondary message, the secondary message could already have fired by the time it came to check, because the `await` from the first update could have let the secondary messages go through.
  -  Now, by using `.then()` all the monitors can do their checks before any secondary messages can be created.
- Improved `checkSecondHook()` to check for more specific messages.