### PR TITLE
fix labels for proficiencies and abilities

### DIFF
--- a/templates/ability.hbs
+++ b/templates/ability.hbs
@@ -1,5 +1,5 @@
 <div class="dnd5e-cm-content">
     <span class="dnd5e-cm-text">
-        {{characterName}} | {{ability.label}} {{#if ability.old}}{{ability.old}} -> {{/if}}{{ability.value}}
+        {{characterName}} | {{ability.label.label}} {{#if ability.old}}{{ability.old}} -> {{/if}}{{ability.value}}
     </span>
 </div>

--- a/templates/proficiency.hbs
+++ b/templates/proficiency.hbs
@@ -1,5 +1,5 @@
 <div class="dnd5e-cm-content">
     <span class="dnd5e-cm-text">
-        {{characterName}} | {{proficiency.label}} - {{proficiency.value}}
+        {{characterName}} | {{proficiency.label.label}} - {{proficiency.value}}
     </span>
 </div>


### PR DESCRIPTION
Now the object for Abilities and Proficiencies have the label property as an object, this fix should solve the folowing issue:

![image](https://github.com/jessev14/dnd5e-character-monitor/assets/41312800/9fbb0e38-a577-4672-9b07-2b9831bbccb9)
_Before and After the fix_