### PR TITLE
FIX: Remove extra label call in ability and proficiency templates

### DIFF
--- a/templates/ability.hbs
+++ b/templates/ability.hbs
@@ -1,5 +1,5 @@
 <div class="dnd5e-cm-content">
     <span class="dnd5e-cm-text">
-        {{characterName}} | {{ability.label.label}} {{#if ability.old}}{{ability.old}} -> {{/if}}{{ability.value}}
+        {{characterName}} | {{ability.label}} {{#if ability.old}}{{ability.old}} -> {{/if}}{{ability.value}}
     </span>
 </div>

--- a/templates/proficiency.hbs
+++ b/templates/proficiency.hbs
@@ -1,5 +1,5 @@
 <div class="dnd5e-cm-content">
     <span class="dnd5e-cm-text">
-        {{characterName}} | {{proficiency.label.label}} - {{proficiency.value}}
+        {{characterName}} | {{proficiency.label}} - {{proficiency.value}}
     </span>
 </div>


### PR DESCRIPTION
Previously I made a fix for the labels of Abilities and Proficiencies not being called correctly on the v11 of Foundry: The label atribute was now a level deeper in the object. 

User Halftonex fixed the same issue by sending the correct label to the template, but I edited the template directly, and both our fixes are implemented in the current 1.8.0 release, wich basically causes the same bug we intended to fix in the first place.

By reverting the fix I made back then, it should work perfectly on v11

![image](https://github.com/jessev14/dnd5e-character-monitor/assets/41312800/b0124bc3-df71-4a3f-aef4-31e57c7206f2)
_Before and After the fix_