### PR TITLE
GM only tracking fix

### DIFF
--- a/scripts/dnd5e-character-monitor.js
+++ b/scripts/dnd5e-character-monitor.js
@@ -352,7 +352,7 @@ Hooks.on('preUpdateItem', async (item, diff, options, userID) => {
     if (!(isEquip || isQuantity || isSpellPrep || isFeat || isAttune)) return;
 
     const whisper = game.settings.get(moduleID, 'showGMonly')
-        ? game.users.filter(u => item.parent.testUserPermission(u, CONST.DOCUMENT_PERMISSION_LEVELS.OWNER)).map(u => u.id)
+        ? game.users.filter(u => item.parent.testUserPermission(u, CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER)).map(u => u.id)
         : null;
 
     const characterName = game.settings.get(moduleID, 'useTokenName') ? (actor.token?.name || actor.prototypeToken.name) : actor.name;


### PR DESCRIPTION
Moved to a v12-compatible ownership constant
`CONST.DOCUMENT_PERMISSION_LEVELS.OWNER` is a v9 holdover, and is no longer available in v12, crippling majority of the plugin functionality when the showGMonly flag is set.
As such `CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER` introduced in v10 and available in v12 was substituted in.